### PR TITLE
Add blocktype field to transaction schema

### DIFF
--- a/models/tx.js
+++ b/models/tx.js
@@ -9,6 +9,7 @@ var TxSchema = new Schema({
   timestamp: { type: Number, default: 0, index: true },
   blockhash: { type: String, index: true },
   blockindex: {type: Number, default: 0, index: true},
+  blocktype: { type: String, index: true },
 }, {id: false});
 
 TxSchema.index({total: 1, total: -1, blockindex: 1, blockindex: -1});


### PR DESCRIPTION
## Summary
- add `blocktype` field to `Tx` schema for indexing transaction type

## Testing
- `npm test` *(fails: Expected 0 to equal 18; Cannot read properties of undefined; RangeError: Maximum call stack size exceeded; module not found '../lib/poloniex')*

------
https://chatgpt.com/codex/tasks/task_e_689454f38c88833185770fe3c2ffbbd1