### PR TITLE
Include block type in last transactions AJAX response

### DIFF
--- a/app.js
+++ b/app.js
@@ -234,6 +234,7 @@ app.use('/ext/getlasttxsajax/:min', function(req,res){
       row.push(txs[i].vout.length);
       row.push((txs[i].total));
       row.push(new Date((txs[i].timestamp) * 1000).toUTCString());
+      row.push(txs[i].blocktype);
       data.push(row);
     }
     res.json({"data":data, "draw": req.query.draw, "recordsTotal": count, "recordsFiltered": count});


### PR DESCRIPTION
## Summary
- Append block type to each row in `/ext/getlasttxsajax/:min` endpoint while preserving existing column order.

## Testing
- `npm test` *(fails: 12 specs, 6 failures)*

------
https://chatgpt.com/codex/tasks/task_e_689454f8215c83318b3178c2a5b96644