### PR TITLE
Record block consensus flag in transaction

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -110,7 +110,7 @@ function find_tx(txid, cb) {
   });
 }
 
-function save_tx(txid, blockheight, cb) {
+function save_tx(txid, blockheight, blocktype, cb) {
   //var s_timer = new Date().getTime();
   lib.get_rawtransaction(txid, function(tx){
     if (tx != 'There was an error. Check your console.') {
@@ -141,6 +141,7 @@ function save_tx(txid, blockheight, cb) {
                   timestamp: tx.time,
                   blockhash: tx.blockhash,
                   blockindex: blockheight,
+                  blocktype: blocktype,
                 });
                 newTx.save(function(err) {
                   if (err) {
@@ -357,7 +358,7 @@ module.exports = {
       } else {
         lib.syncLoop(block.tx.length, function (loop) {
           var i = loop.iteration();
-          save_tx(block.tx[i], block.height, function(err){
+          save_tx(block.tx[i], block.height, block.flags, function(err){
             if (err) {
               loop.next();
             } else {
@@ -782,7 +783,7 @@ module.exports = {
                             next_tx();
                           }, timeout);
                         } else {
-                          save_tx(txid, block_height, function(err){
+                          save_tx(txid, block_height, block.flags, function(err){
                             if (err) {
                               console.log(err);
                             } else {

--- a/models/tx.js
+++ b/models/tx.js
@@ -9,6 +9,7 @@ var TxSchema = new Schema({
   timestamp: { type: Number, default: 0, index: true },
   blockhash: { type: String, index: true },
   blockindex: {type: Number, default: 0, index: true},
+  blocktype: { type: String, default: '' },
 }, {id: false});
 
 TxSchema.index({total: 1, total: -1, blockindex: 1, blockindex: -1});


### PR DESCRIPTION
## Summary
- expand transaction model to persist block consensus flags
- allow save_tx to receive blocktype and include when saving
- pass block flags when saving transactions during block indexing

## Testing
- `npm test` *(fails: 12 specs, 6 failures)*

------
https://chatgpt.com/codex/tasks/task_e_689454f5c10c83318d9ab320fb297276