### PR TITLE
Swap timestamp and block type column order

### DIFF
--- a/app.js
+++ b/app.js
@@ -233,8 +233,8 @@ app.use('/ext/getlasttxsajax/:min', function(req,res){
       row.push(txs[i].txid);
       row.push(txs[i].vout.length);
       row.push((txs[i].total));
+      row.push(txs[i].timestamp ? new Date(txs[i].timestamp * 1000).toUTCString() : 'Unknown');
       row.push(txs[i].blocktype || 'Unknown');
-      row.push(new Date((txs[i].timestamp) * 1000).toUTCString());
       data.push(row);
     }
     res.json({"data":data, "draw": req.query.draw, "recordsTotal": count, "recordsFiltered": count});

--- a/views/index.pug
+++ b/views/index.pug
@@ -62,23 +62,20 @@ block content
           var amount = (data[4] / 100000000).toLocaleString('en',{'minimumFractionDigits':2,'maximumFractionDigits':8,'useGrouping':true}); //variables for better readability
           var amountParts = amount.split('.');
           var amount = amountParts[0] + '.<span class="decimal">' + amountParts[1] + '</span>';
-          var blocktype = data[5]; //variables for better readability
-          var timestamp = data[6]; //variables for better readability
+          var timestamp = data[5]; //variables for better readability
+          var blocktype = data[6]; //variables for better readability
           var labelPoS = '#{settings.locale.proof_of_stake}';
-          var labelPoW = '#{settings.locale.proof_of_work}';
           var labelUnknown = 'Unknown';
-          var typeLabel = labelUnknown;
+          var typeLabel = blocktype || labelUnknown;
           if (blocktype === 'PoS') {
             typeLabel = labelPoS;
-          } else if (blocktype === 'PoW') {
-            typeLabel = labelPoW;
           }
           $("td:eq(0)", row).html('<a href="/block/' + blockhash + '">' + blockindex + '</a>');
           $("td:eq(1)", row).html('<a href="/tx/' + txhash + '">' + txhash + '</a>').addClass("d-none d-md-none d-lg-table-cell text-center");
           $("td:eq(2)", row).html(outputs).addClass("d-none d-md-none d-lg-table-cell text-center");
           $("td:eq(3)", row).html(amount);
-          $("td:eq(4)", row).html(typeLabel);
-          $("td:eq(5)", row).html(timestamp);
+          $("td:eq(4)", row).html(timestamp);
+          $("td:eq(5)", row).html(typeLabel);
         },
       });
       setInterval( function () {
@@ -108,7 +105,7 @@ block content
             th.d-none.d-md-none.d-lg-table-cell.text-center #{settings.locale.tx_hash}
             th.d-none.d-md-none.d-lg-table-cell.text-center #{settings.locale.tx_recipients}
             th.text-center #{settings.locale.mkt_amount} (#{settings.symbol})
-            th.text-center #{settings.locale.tx_type}
             th.text-center #{settings.locale.timestamp}
+            th.text-center #{settings.locale.tx_type}
         tbody.text-center
     .footer-padding

--- a/views/movement.pug
+++ b/views/movement.pug
@@ -66,7 +66,7 @@ block content
           var amount = (data[4] / 100000000).toLocaleString('en',{'minimumFractionDigits':2,'maximumFractionDigits':8,'useGrouping':true}); //variables for better readability
           var amountParts = amount.split('.');
           var amountStr = amountParts[0] + '.<span class="decimal">' + amountParts[1] + '</span>';
-          var timestamp = data[6]; //variables for better readability
+          var timestamp = data[5]; //variables for better readability
           
           $("td:eq(0)", row).html(timestamp);
           $("td:eq(1)", row).html('<a href="/tx/' + txhash + '">' + txhash + '</a>');


### PR DESCRIPTION
## Summary
- Send timestamp before block type in `/ext/getlasttxsajax/:min`
- Read timestamp from `data[5]` and block type from `data[6]` in index view
- Update movement view to pull timestamp from the new index position
- Allow mining pool names to display for PoW blocks by not forcing the PoW label

## Testing
- `npm test` (fails: 12 specs, 6 failures)


------
https://chatgpt.com/codex/tasks/task_e_68a00a6136ac833198e71ef682e97012